### PR TITLE
added path to slurm dependencies lib

### DIFF
--- a/launcher.sh
+++ b/launcher.sh
@@ -79,6 +79,8 @@ SCIPSLURM_HOSTSCONF=/path/to/your/hosts.conf
 SCIPSLURM_BIN="/usr/bin"
 SCIPSLURM_BASE=/etc/slurm-llnl
 SCIPSLURM_LIB=/var/lib/slurm-llnl
+# UNCOMMENT THIS LINE IF YOUR SCIPSLURM_LIB HAS MORE LIBRARIES APPART FROM THE SLURM ONE
+#SCIPSLURM_LIB_DEPENDENCIES="--bind /lib/x86_64-linux-gnu/libc.so.* --bind /lib/x86_64-linux-gnu/libm.so.* --bind /lib/x86_64-linux-gnu/libresolv.so.* --bind /lib64/ld-linux-x86-64.so.*"
 SCIPSLURM_PLUGINS=/usr/lib/x86_64-linux-gnu/slurm-wlm/
 # Usual locations (check your specific case)
 # BIN -> /usr/bin, /opt/slurm/bin, /bin
@@ -91,7 +93,7 @@ SCIPSLURM_JOBS=" --bind $SCIPSLURM_BIN/sbatch --bind $SCIPSLURM_BIN/srun --bind 
 SCIPSLURM_CTRL=" --bind $SCIPSLURM_BIN/squeue --bind $SCIPSLURM_BIN/sinfo \
                  --bind $SCIPSLURM_BIN/scontrol --bind $SCIPSLURM_BIN/sstat --bind $SCIPSLURM_BIN/sacct "
 SCIPSLURM_CONF=" --bind $SCIPSLURM_BASE --bind $SCIPSLURM_HOSTSCONF:/scipion/config/hosts.conf "
-SCIPSLURM_LIBS=" --bind $SCIPSLURM_LIB --bind $SCIPSLURM_PLUGINS "
+SCIPSLURM_LIBS=" --bind $SCIPSLURM_LIB --bind $SCIPSLURM_LIB_DEPENDENCIES --bind $SCIPSLURM_PLUGINS "
 # UNCOMMENT THIS LINE WHEN USING SLURM
 #SCIPSLURM_CMD=" $SCIPSLURM_JOBS $SCIPSLURM_CTRL $SCIPSLURM_CONF $SCIPSLURM_LIBS "
 # END OF SLURM CONFIGURATION VARIABLES

--- a/launcher.sh
+++ b/launcher.sh
@@ -80,12 +80,14 @@ SCIPSLURM_BIN="/usr/bin"
 SCIPSLURM_BASE=/etc/slurm-llnl
 SCIPSLURM_LIB=/var/lib/slurm-llnl
 # UNCOMMENT THIS LINE IF YOUR SCIPSLURM_LIB HAS MORE LIBRARIES APPART FROM THE SLURM ONE
-#SCIPSLURM_LIB_DEPENDENCIES="--bind /lib/x86_64-linux-gnu/libc.so.* --bind /lib/x86_64-linux-gnu/libm.so.* --bind /lib/x86_64-linux-gnu/libresolv.so.* --bind /lib64/ld-linux-x86-64.so.*"
+#SCIPSLURM_LIB_DEPENDENCIES="--bind /lib/x86_64-linux-gnu/libc.so.* --bind /lib/x86_64-linux-gnu/libm.so.* --bind /lib/x86_64-linux-gnu/libresolv.so.* --bind /lib/x86_64-linux-gnu/ld-linux-x86-64.so.*"
 SCIPSLURM_PLUGINS=/usr/lib/x86_64-linux-gnu/slurm-wlm/
 # Usual locations (check your specific case)
 # BIN -> /usr/bin, /opt/slurm/bin, /bin
 # BASE -> /etc/slurm-llnl, /etc/slurm
 # LIB -> /var/lib/slurm-llnl (ubuntu apt), /var/lib/slurm (ubuntu sources), /usr/lib64/slurm
+# LIB_DEPENDENCIES -> ubuntu: /lib/x86_64-linux-gnu/libc.so.*, /lib/x86_64-linux-gnu/libm.so.*, /lib/x86_64-linux-gnu/libresolv.so.*, /lib/x86_64-linux-gnu/ld-linux-x86-64.so.* 
+                      CentOS: /lib64/libc.so.*, /lib64/libm.so.*, /lib64/libresolv.so.*, /lib64/ld-linux-x86-64.so.*
 # PLUGINS -> /usr/lib/x86_64-linux-gnu/slurm-wlm/ (ubuntu apt), /usr/lib64/slurm (CentOS)
 ###
 # DONT TOUCH THESE

--- a/launcher.sh
+++ b/launcher.sh
@@ -87,7 +87,7 @@ SCIPSLURM_PLUGINS=/usr/lib/x86_64-linux-gnu/slurm-wlm/
 # BASE -> /etc/slurm-llnl, /etc/slurm
 # LIB -> /var/lib/slurm-llnl (ubuntu apt), /var/lib/slurm (ubuntu sources), /usr/lib64/slurm
 # LIB_DEPENDENCIES -> ubuntu: /lib/x86_64-linux-gnu/libc.so.*, /lib/x86_64-linux-gnu/libm.so.*, /lib/x86_64-linux-gnu/libresolv.so.*, /lib/x86_64-linux-gnu/ld-linux-x86-64.so.* 
-                      CentOS: /lib64/libc.so.*, /lib64/libm.so.*, /lib64/libresolv.so.*, /lib64/ld-linux-x86-64.so.*
+#                     CentOS: /lib64/libc.so.*, /lib64/libm.so.*, /lib64/libresolv.so.*, /lib64/ld-linux-x86-64.so.*
 # PLUGINS -> /usr/lib/x86_64-linux-gnu/slurm-wlm/ (ubuntu apt), /usr/lib64/slurm (CentOS)
 ###
 # DONT TOUCH THESE


### PR DESCRIPTION
If libslurm.so.40 is not in a dedicated path such as /var/lib/slurm-llnl but in a generic one like /usr/lib/x86_64-linux-gnu/ binding this latter one will crash with container libraries. But if we use just /usr/lib/x86_64-linux-gnu/libslurm.so.*, there will be some missing dependencies. Here we bind them too.