### PR TITLE
Add 'anaconda' channel to conda configuration in apptainer-base.def

### DIFF
--- a/apptainer/apptainer-base.def
+++ b/apptainer/apptainer-base.def
@@ -43,6 +43,9 @@ echo 'export PATH="/opt/miniforge3/bin:${PATH}"' >> $SINGULARITY_ENVIRONMENT
 . /opt/miniforge3/etc/profile.d/conda.sh
 export PATH="/opt/miniforge3/bin:${PATH}"
 
+# Add 'anaconda' channel to conda to access required packages during installation
+conda config --add channels anaconda
+
 # Scipion installation
 conda run -n base pip3 install --user scipion-installer scons numpy
 conda run -n base python3 -m scipioninstaller -conda -noAsk /scipion


### PR DESCRIPTION
Added 'anaconda' channel to allow deepLearningToolkit to find required packages during installation. Without this, since the channel list was updated (and no longer contained 'anaconda'), the installation would fail.